### PR TITLE
Require Ruby 2.3 or better

### DIFF
--- a/reamaze_api.gemspec
+++ b/reamaze_api.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.2.0"
+  spec.required_ruby_version = ">= 2.3.0"
 
   spec.add_dependency "faraday",            ">= 0.9.2", "< 1.0"
   spec.add_dependency "faraday_middleware", ">= 0.9.0", "< 1.0"


### PR DESCRIPTION
**MERGE AFTER 2018-03-31**

Ruby 2.2 reaches end of life on 2018-03-31. After that date, require Ruby 2.3 or better, and cut a new release.